### PR TITLE
Bugfix var_dump

### DIFF
--- a/src/Laravelrus/LocalizedCarbon/DiffFormatters/FrDiffFormatter.php
+++ b/src/Laravelrus/LocalizedCarbon/DiffFormatters/FrDiffFormatter.php
@@ -9,8 +9,6 @@ class FrDiffFormatter implements DiffFormatterInterface {
 
         $txt = $delta . ' ' . $unitStr;
 
-        var_dump($isNow, $isFuture);
-
         if ($isNow) {
             $when = ($isFuture) ?  'Dans ' : 'Il y a ';
             return $when . $txt;


### PR DESCRIPTION
Hi,
Your project nealry saved my life a few days ago, but I discovered there was a `var_dump` left in the french DiffFormater. Here is a modified version of the file without it.
