### PR TITLE
Wrong calculations on big dates diffs!

### DIFF
--- a/src/Laravelrus/LocalizedCarbon/LocalizedCarbon.php
+++ b/src/Laravelrus/LocalizedCarbon/LocalizedCarbon.php
@@ -30,13 +30,14 @@ class LocalizedCarbon extends Carbon {
 
         $delta = $other->diffInSeconds($this);
 
-        // 4 weeks per month, 365 days per year... good enough!!
+        // 4.35 weeks per year. 365 days in a year, 12 months, 7 days in a week:
+        // 365/12/7 = 4.345238095238095 4.35 is good enough for big time calculations!
         $divs = array(
             'second' => self::SECONDS_PER_MINUTE,
             'minute' => self::MINUTES_PER_HOUR,
             'hour'   => self::HOURS_PER_DAY,
             'day'    => self::DAYS_PER_WEEK,
-            'week'   => 4,
+            'week'   => 4.35,
             'month'  => self::MONTHS_PER_YEAR
         );
 


### PR DESCRIPTION
When trying to make diff dates with big delta, user faced with wrong calculations. For example diff with dates 01.01.1974 and now (20.01.2015) is showing 44 years. Obviously it is wrong because diff is 41 years.

4 weeks per month is does its work!

Average number of weeks in a year is 4.35: 365 days in a year, 12 months, 7 days in a week, 365/12/7 = 4.345238095238095. 4.35 is good enough for big time calculations! If this parameter is used - everything is calculates with excellent accuracy!